### PR TITLE
Issue-405: Changed detekt rules for UnusedPrivateMember

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -525,8 +525,7 @@ style:
   UnusedPrivateClass:
     active: true
   UnusedPrivateMember:
-    active: true
-    allowedNames: '(_|ignored|expected|serialVersionUID)'
+    active: false
   UseDataClass:
     active: false
     excludeAnnotatedClasses: ""


### PR DESCRIPTION
#405 . Turn - off this check in detekt, cause it's not suppressed with SuppressWarning annotation. And Lint also checks unused member/method. 